### PR TITLE
Added doc lookup feature

### DIFF
--- a/UnityDocsBot/Services/DocLookupService.cs
+++ b/UnityDocsBot/Services/DocLookupService.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.IO;
+using System.Linq;
+
+namespace UnityDocsBot.Services
+{
+    public class DocLookupService
+    {
+        readonly string lookupFile = "lookup.json";
+
+        public DocLookupService()
+        {
+            if (!File.Exists(lookupFile))
+                File.WriteAllText(lookupFile, "{ }");
+        }
+
+        public bool TryGet(string name, out string[] docs)
+        {
+            docs = new string[0];
+
+            var json = JObject.Parse(File.ReadAllText(lookupFile));
+
+            if (json.TryGetValue(name, out var token))
+            {
+                docs = ((JArray)token).Select(t => (string)t).ToArray();
+                return docs.Length > 0;
+            }
+            else
+            {
+                json.Add(name, new JArray());
+                File.WriteAllText(lookupFile, json.ToString(Formatting.Indented));
+            }
+
+            return false;
+        }
+    }
+}

--- a/UnityDocsBot/UnityBotClient.cs
+++ b/UnityDocsBot/UnityBotClient.cs
@@ -56,6 +56,7 @@ namespace UnityDocsBot
                 .AddSingleton(_versions)
                 .AddSingleton<CommandService>()
                 .AddSingleton<CommandHandlingService>()
+                .AddSingleton<DocLookupService>()
                 // Logging
                 .AddSingleton<LoggingService>()
                 // Add additional services here...


### PR DESCRIPTION
This adds a `DocLookupService` that uses a `lookup.json` file to get the answer to any query not in the documentation.

The format of the file is like this.

```
{
  "<SEARCH TEXT>": [ "DESCRIPTION", "FULL REFERENCE" ],
  "ECS": [ "Unity ECS Forums", "https://forum.unity.com/forums/entity-component-system-and-c-job-system.147/" ]
}
```